### PR TITLE
Desired usage API v0.1 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,29 @@ Create a worker for consuming an SQS queue (Paul: I'm not sure about this API fo
 sqs-utils.core> (doc handle-queue)
 -------------------------
 sqs-utils.core/handle-queue
-([sqs-config queue-url handler-fn {:keys [num-handler-threads auto-delete], :or {num-handler-threads 4, auto-delete true}, :as opts}]
- [sqs-config queue-url handler-fn])
+[aws-creds queue-config handler-fn]
+
   Set up a loop that listens to a queue and process incoming messages.
 
    Arguments:
-   sqs-config  - A map of the following keys, used for interacting with SQS:
-      access-key - AWS access key ID
-      secret-key - AWS secret access key
-      endpoint   - SQS queue endpoint - usually an HTTPS based URL
-      region     - AWS region
-      s3-bucket  - ARN (or whatever URI needed to point to an existing S3, TBD what minimal setting we need to pass in here)
-   queue-url  - URL of the queue
+
+   aws-creds - A map of the following credential keys, used for interacting with SQS:
+     access-key   - AWS access key ID
+     secret-key   - AWS secret access key
+     sqs-endpoint - SQS queue endpoint - usually an HTTPS based URL (Paul: this seems redundant to queue-url)
+     region       - AWS region
+
+   queue-config - A map of the configuration for this queue
+     queue-url     - required: URL of the queue
+     s3-bucket-arn - optional: ARN (or whatever URI needed to point to an existing S3, TBD what minimal setting we need to pass in here)
+     num-handler-threads - optional: how many threads to run (defaults: 4)
+     auto-delete   - optional: boolean, if true, immediately delete the message,
+                     if false, forward a `done` function and leave the
+                     message intact. (defaults: true)
+
    handler-fn - a function which will be passed the incoming message. If
                 auto-delete is false, a second argument will be passed a `done`
                 function to call when finished processing.
-   opts       - an optional map containing the following keys:
-      num-handler-threads - how many threads to run (defaults: 4)
-
-      auto-delete        - boolean, if true, immediately delete the message,
-                           if false, forward a `done` function and leave the
-                           message intact. (defaults: true)
 
   Returns:
   a kill function - call the function to terminate the loop.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # clj-sqs-extended
 
-## Usage
+## API Highlight
 
 Create a worker for consuming an SQS queue (Paul: I'm not sure about this API for handle-queue yet):
 
@@ -43,13 +43,13 @@ Send messages to a queue:
 sqs-utils.core> (doc send-message)
 -------------------------
 sqs-utils.core/send-message
-[sqs-config queue-url payload]
+[aws-creds queue-url payload]
   Send a message to a standard queue.
-=> nil
+=> nil (Paul: could we return the message ID? or whatever ID that the library returns for the message?)
 sqs-utils.core> (doc send-fifo-message)
 -------------------------
 sqs-utils.core/send-fifo-message
-[sqs-config queue-url payload {message-group-id :message-group-id, deduplication-id :deduplication-id, :as options}]
+[aws-creds queue-url payload {message-group-id :message-group-id, deduplication-id :deduplication-id, :as options}]
   Send a message to a FIFO queue.
 
   Argments:
@@ -63,4 +63,44 @@ sqs-utils.core/send-fifo-message
 ```
 
 ## Example
+
+
+```clj
+(defn dispatch-action-service
+ [{foo :foo} done-fn]
+ (println (format "I got %s" foo))
+ (done-fn))
+
+(defn start-action-service-queue-listener
+ []
+ (sqs-utils/handle-queue
+  (queue/aws-creds)
+  (queue/queue-config :action-service)
+  dispatch-action-service))
+
+(defn start-queue-listeners
+  "Start all the queue listener loops. Returns a function which stops them all."
+  []
+  (let [stop-fns [(start-action-service-queue-listener)]]
+    (fn []
+      (doseq [stop-fn stop-fns]
+        (stop-fn)))))
+
+(defn start-worker
+  "Starts queue workers and blocks indefinitely"
+  []
+  (let [sigterm (java.util.concurrent.CountDownLatch. 1)]
+    (log/info "Starting queue workers...")
+    (start-queue-listeners)
+
+    ;; blocks main from exiting
+    (.await sigterm)))
+
+;; start this in the background
+(future (start-worker))
+
+(send-message (queue/aws-creds) (queue/queue-url :action-service) {:foo "potatoes"})
+=> nil
+"I got potatoes"
+```
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
 # clj-sqs-extended
+
+## Usage
+
+Create a worker for consuming an SQS queue (Paul: I'm not sure about this API for handle-queue yet):
+
+```
+sqs-utils.core> (doc handle-queue)
+-------------------------
+sqs-utils.core/handle-queue
+([sqs-config queue-url handler-fn {:keys [num-handler-threads auto-delete], :or {num-handler-threads 4, auto-delete true}, :as opts}]
+ [sqs-config queue-url handler-fn])
+  Set up a loop that listens to a queue and process incoming messages.
+
+   Arguments:
+   sqs-config  - A map of the following keys, used for interacting with SQS:
+      access-key - AWS access key ID
+      secret-key - AWS secret access key
+      endpoint   - SQS queue endpoint - usually an HTTPS based URL
+      region     - AWS region
+      s3-bucket  - ARN (or whatever URI needed to point to an existing S3, TBD what minimal setting we need to pass in here)
+   queue-url  - URL of the queue
+   handler-fn - a function which will be passed the incoming message. If
+                auto-delete is false, a second argument will be passed a `done`
+                function to call when finished processing.
+   opts       - an optional map containing the following keys:
+      num-handler-threads - how many threads to run (defaults: 4)
+
+      auto-delete        - boolean, if true, immediately delete the message,
+                           if false, forward a `done` function and leave the
+                           message intact. (defaults: true)
+
+  Returns:
+  a kill function - call the function to terminate the loop.
+=> nil
+```
+
+Send messages to a queue:
+
+```
+sqs-utils.core> (doc send-message)
+-------------------------
+sqs-utils.core/send-message
+[sqs-config queue-url payload]
+  Send a message to a standard queue.
+=> nil
+sqs-utils.core> (doc send-fifo-message)
+-------------------------
+sqs-utils.core/send-fifo-message
+[sqs-config queue-url payload {message-group-id :message-group-id, deduplication-id :deduplication-id, :as options}]
+  Send a message to a FIFO queue.
+
+  Argments:
+  message-group-id - a tag that specifies the group that this message
+  belongs to. Messages belonging to the same group
+  are guaranteed FIFO
+
+  Options:
+  deduplication-id -  token used for deduplication of sent messages
+=> nil
+```
+
+## Example
+


### PR DESCRIPTION
I copied the usage readme from sqs-utils and drafted an usage example. `send-message` and `send-fifo-message` could have the same API. I tweaked `handle-queue` by:

1. removed `visibility-timeout` as I find that it's better to set that on the queue configuration and not through the client.
2. adding a `s3-bucket` parameter to `queue-config` to point to the s3 bucket that this queue should use as message storage. The idea is that we'll create and setup the S3 bucket separately once in our devops and then just pass the URL/ARN here. I don't want us to be creating infrastructure assets in client code.