### PR TITLE
fix circleci test result directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           command: lein test :all
 
       - store_test_results:
-          path: ~/test_output
+          path: target/test_output
 
       - save_cache:
           paths:

--- a/dev/resources/circleci_test/config.clj
+++ b/dev/resources/circleci_test/config.clj
@@ -1,6 +1,6 @@
 (require '[circleci.test.report.junit :as junit])
 
-{:test-results-dir "target/test-results"
+{:test-results-dir "target/test_output"
  :reporters        [circleci.test.report/clojure-test-reporter
                     junit/reporter]
 


### PR DESCRIPTION
this was broken e.g. https://app.circleci.com/pipelines/github/Motiva-AI/clj-sqs-extended/66/workflows/5a93d526-5d31-403a-93a0-0c3a1a29ee8e/jobs/66/parallel-runs/0/steps/0-107