### PR TITLE
Refactor receive-loop to not rely on statefulness (i.e. the external atom)

### DIFF
--- a/src/clj_sqs_extended/aws/sqs.clj
+++ b/src/clj_sqs_extended/aws/sqs.clj
@@ -245,10 +245,7 @@
           (when-not (async-protocols/closed? ch)
             (recur)))
         (catch Throwable e
-          (>! ch e)))
-
-      ;; before exiting go-loop
-      (async/close! ch))
+          (>! ch e))))
 
     ch))
 

--- a/src/clj_sqs_extended/aws/sqs.clj
+++ b/src/clj_sqs_extended/aws/sqs.clj
@@ -245,7 +245,10 @@
           (when-not (async-protocols/closed? ch)
             (recur)))
         (catch Throwable e
-          (>! ch e))))
+          (>! ch e)))
+
+      ;; close channel when exiting loop
+      (async/close! ch))
 
     ch))
 

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -161,14 +161,16 @@
     (create-new-receiving-chan-fn)
     current-receiving-chan))
 
-;; TODO rename this to e.g. process-message-loop
+;; TODO rename this to e.g. process-message-loop because there's another loop
+;; in receive-to-channel so the term is not clear anymore
 (defn receive-loop
   ([sqs-ext-client queue-url out-chan]
    (receive-loop sqs-ext-client queue-url out-chan {}))
 
   ([sqs-ext-client queue-url out-chan
     {:keys [auto-delete
-            restart-delay-seconds]
+            restart-delay-seconds
+            restart-limit]
      :as   receive-opts}]
    (let [receive-loop-running? (atom true)]
      (go-loop

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -39,7 +39,7 @@
 
         (cond-> paused-for-error? (update :restart-count inc)))))
 
-(defn- stop-receive-loop!
+(defn stop-receive-loop!
   [queue-url receiving-chan out-chan ^clojure.lang.Atom receive-loop-running?]
   (log/infof "Stopping receive-loop for %s ..." queue-url)
   (reset! receive-loop-running? false)

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -79,11 +79,16 @@
                 (not auto-delete?) (assoc :done-fn done-fn))]
       (if (:body message)
         (when-not (>!! out-chan msg)
+          ;; TODO refactor this fn's logic so that we don't need to throw an exception to stop auto-delete
+
+          ;; throwing an exception here to stop the process so that we don't
+          ;; delete the current received message without putting it to out-chan
           (throw (ex-info
                    (format "Failed to put message to out-chan because the channel is closed already. Queue %s"
                            queue-url)
                    {})))
 
+        ;; Question: do we need to delete a nil message?
         (log/infof "Queue '%s' received a nil (:body message), message: %s"
                    queue-url
                    message))

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -41,11 +41,11 @@
 
 (defn stop-receive-loop!
   [queue-url out-chan ^clojure.lang.Atom receive-loop-running?]
-  (log/infof "Stopping receive-loop for %s ..." queue-url)
+  (log/infof "Stopping receive-loop for %s, watch for terminating message coming..." queue-url)
   (reset! receive-loop-running? false)
   (close! out-chan))
 
-(defn- exit-receive-loop!
+(defn exit-receive-loop!
   [queue-url loop-stats receiving-chan]
   (log/infof "Receive-loop terminated for %s, stats: %s" queue-url loop-stats)
   (close! receiving-chan)

--- a/test/clj_sqs_extended/core_test.clj
+++ b/test/clj_sqs_extended/core_test.clj
@@ -1,6 +1,6 @@
 (ns clj-sqs-extended.core-test
   (:require [clojure.test :refer [use-fixtures deftest testing is are]]
-            [clojure.core.async :as async :refer [chan close! timeout alt!! alts!! thread]]
+            [clojure.core.async :refer [chan close! <!! timeout alt!! alts!! thread]]
             [bond.james :as bond]
             [clj-sqs-extended.aws.sqs :as sqs]
             [clj-sqs-extended.core :as sqs-ext]
@@ -77,12 +77,12 @@
             (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
                                                @fixtures/test-queue-url
                                                message)))
-            (is (= message (timed-take!! handler-chan)))
+            (is (= message (<!! handler-chan)))
 
             (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
                                                @fixtures/test-queue-url
                                                message)))
-            (is (= message (timed-take!! handler-chan)))))
+            (is (= message (<!! handler-chan)))))
 
         (testing "handle-queue can send/receive large message to standard queue"
           (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
@@ -136,7 +136,7 @@
                                                 message
                                                 (helpers/random-group-id))))
 
-        (is (= message (async/<!! handler-chan)))))))
+        (is (= message (<!! handler-chan)))))))
 
 (deftest handle-queue-terminates-with-non-existing-queue
   (let [handler-chan (chan)]

--- a/test/clj_sqs_extended/core_test.clj
+++ b/test/clj_sqs_extended/core_test.clj
@@ -232,7 +232,7 @@
           #(let [stats (fixtures/with-handle-queue-defaults
                          handler-chan)]
              (Thread/sleep 500)
-             (is (= (:restart-count stats) 0))
+             (is (= 0 (:restart-count stats)))
              (is (contains? stats :stopped-at)))))
       (close! handler-chan))))
 
@@ -388,15 +388,14 @@
 
         (close! handler-chan)))))
 
-(deftest recoverable-errors-get-judged-properly
-  (testing "error-might-be-recovered-by-restarting? judges errors correctly"
-    (are [severity error]
-      (= severity (receive/error-might-be-recovered-by-restarting? error))
-      true (UnknownHostException.)
-      true (SocketException.)
-      true (HttpTimeoutException. "test")
-      false (RuntimeException.)
-      false (ReflectiveOperationException.))))
+(deftest error-is-safe-to-continue?-test
+  (are [severity error]
+       (= severity (receive/error-is-safe-to-continue? error))
+       true (UnknownHostException.)
+       true (SocketException.)
+       true (HttpTimeoutException. "test")
+       false (RuntimeException.)
+       false (ReflectiveOperationException.)))
 
 (deftest unreachable-endpoint-yields-proper-exception
   (testing "Trying to connect to an unreachable endpoint yields a proper exception"

--- a/test/clj_sqs_extended/core_test.clj
+++ b/test/clj_sqs_extended/core_test.clj
@@ -89,55 +89,52 @@
       (close! handler-chan))))
 
 (deftest handle-queue-sends-and-receives-messages-without-bucket
-  (testing "handle-queue can send/receive message without using a s3 bucket"
-    (let [handler-chan (chan)
-          sqs-ext-config-without-bucket (dissoc fixtures/sqs-ext-config
-                                                :s3-bucket-name)]
-      (fixtures/with-test-standard-queue
-        (fixtures/with-handle-queue
-          handler-chan
-          {:sqs-ext-config {:s3-bucket-name nil}}
+  (let [handler-chan (chan)
+        sqs-ext-config-without-bucket (dissoc fixtures/sqs-ext-config
+                                              :s3-bucket-name)]
+    (fixtures/with-test-standard-queue
+      (fixtures/with-handle-queue
+        handler-chan
+        {:sqs-ext-config {:s3-bucket-name nil}}
 
-          (is (string? (sqs-ext/send-message sqs-ext-config-without-bucket
-                                             @fixtures/test-queue-url
-                                             (first test-messages-basic))))
-          (is (= (first test-messages-basic) (<!! handler-chan)))
-          (is (string? (sqs-ext/send-message sqs-ext-config-without-bucket
-                                             @fixtures/test-queue-url
-                                             test-message-with-time)))
-          (is (= test-message-with-time (<!! handler-chan)))))
-      (close! handler-chan))))
+        (is (string? (sqs-ext/send-message sqs-ext-config-without-bucket
+                                           @fixtures/test-queue-url
+                                           (first test-messages-basic))))
+        (is (= (first test-messages-basic) (<!! handler-chan)))
+        (is (string? (sqs-ext/send-message sqs-ext-config-without-bucket
+                                           @fixtures/test-queue-url
+                                           test-message-with-time)))
+        (is (= test-message-with-time (<!! handler-chan)))))
+    (close! handler-chan)))
 
 (deftest handle-queue-sends-and-receives-timestamped-message
-  (testing "handle-queue can send/receive message including timestamp to standard queue"
+  (let [handler-chan (chan)]
+    (fixtures/with-test-standard-queue
+      (fixtures/with-handle-queue-defaults
+        handler-chan
+
+        (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
+                                           @fixtures/test-queue-url
+                                           test-message-with-time)))
+        (is (= test-message-with-time (<!! handler-chan)))))
+    (close! handler-chan)))
+
+(deftest handle-queue-sends-and-receives-fifo-messages
+  (doseq [format [:transit :json]]
     (let [handler-chan (chan)]
-      (fixtures/with-test-standard-queue
+      (fixtures/with-test-fifo-queue
         (fixtures/with-handle-queue-defaults
           handler-chan
 
-          (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
-                                             @fixtures/test-queue-url
-                                             test-message-with-time)))
-          (is (= test-message-with-time (<!! handler-chan)))))
+          (let [message (first test-messages-basic)]
+            (is (string? (sqs-ext/send-fifo-message fixtures/sqs-ext-config
+                                                    @fixtures/test-queue-url
+                                                    message
+                                                    (helpers/random-group-id)
+                                                    {:format format})))
+
+            (is (= message (<!! handler-chan))))))
       (close! handler-chan))))
-
-(deftest handle-queue-sends-and-receives-fifo-messages
-  (testing "handle-queue can send/receive basic messages to FIFO queue"
-    (doseq [format [:transit :json]]
-      (let [handler-chan (chan)]
-        (fixtures/with-test-fifo-queue
-          (fixtures/with-handle-queue-defaults
-            handler-chan
-
-            (let [message (first test-messages-basic)]
-              (is (string? (sqs-ext/send-fifo-message fixtures/sqs-ext-config
-                                                      @fixtures/test-queue-url
-                                                      message
-                                                      (helpers/random-group-id)
-                                                      {:format format})))
-
-              (is (= message (<!! handler-chan))))))
-        (close! handler-chan)))))
 
 (deftest handle-queue-terminates-with-non-existing-queue
   (let [handler-chan (chan)]
@@ -175,147 +172,142 @@
     (close! handler-chan)))
 
 (deftest handle-queue-terminates-after-restart-count-exceeded
-  (testing "handle-queue terminates when the restart-count exceeds the limit"
-    (let [handler-chan          (chan)
-          restart-limit         2
-          restart-delay-seconds 1]
-      (fixtures/with-test-standard-queue
-        ;; WATCHOUT: We redefine receive-messages to permanently cause an error to be handled,
-        ;;           which is recoverable by restarting and should cause the loop to be restarted
-        ;;           by an amount of times that fits the restart-limit and delay settings.
-        (bond/with-spy [receive/exit-receive-loop!]
-          (with-redefs-fn {#'sqs/wait-and-receive-messages-from-sqs
-                           (fn [_ _ _] (throw (HttpTimeoutException.
-                                                "Testing permanent network failure")))}
-            #(fixtures/with-handle-queue
-               handler-chan
-               {:handler-opts {:restart-limit         restart-limit
-                               :restart-delay-seconds restart-delay-seconds}}
+  (let [handler-chan          (chan)
+        restart-limit         2
+        restart-delay-seconds 1]
+    (fixtures/with-test-standard-queue
+      ;; WATCHOUT: We redefine receive-messages to permanently cause an error to be handled,
+      ;;           which is recoverable by restarting and should cause the loop to be restarted
+      ;;           by an amount of times that fits the restart-limit and delay settings.
+      (bond/with-spy [receive/exit-receive-loop!]
+        (with-redefs-fn {#'sqs/wait-and-receive-messages-from-sqs
+                         (fn [_ _ _] (throw (HttpTimeoutException.
+                                              "Testing permanent network failure")))}
+          #(fixtures/with-handle-queue
+             handler-chan
+             {:handler-opts {:restart-limit         restart-limit
+                             :restart-delay-seconds restart-delay-seconds}}
 
-               ;; wait for restarts to have time to happen
-               (Thread/sleep (+ (* restart-limit
-                                   (* restart-delay-seconds 1000))
-                                500))))
+             ;; wait for restarts to have time to happen
+             (Thread/sleep (+ (* restart-limit
+                                 (* restart-delay-seconds 1000))
+                              500))))
 
-          ;; wait for receive-loop to teardown
-          (Thread/sleep 1000)
+        ;; wait for receive-loop to teardown
+        (Thread/sleep 1000)
 
-          (let [exit-calls (-> receive/exit-receive-loop!
-                               (bond/calls))]
-            (is (= 1 (count exit-calls)))
-            (is (= restart-limit
-                   (-> exit-calls (first) (:return) (:restart-count)))))))
+        (let [exit-calls (-> receive/exit-receive-loop!
+                             (bond/calls))]
+          (is (= 1 (count exit-calls)))
+          (is (= restart-limit
+                 (-> exit-calls (first) (:return) (:restart-count)))))))
 
-      (close! handler-chan))))
+    (close! handler-chan)))
 
 (deftest handle-queue-restarts-if-recoverable-errors-occurs
-  (testing "handle-queue restarts properly and continues running upon recoverable error"
-    (let [handler-chan (chan)
-          wait-and-receive-messages-from-sqs sqs/wait-and-receive-messages-from-sqs
-          called-counter (atom 0)]
-      (fixtures/with-test-standard-queue
-        ;; WATCHOUT: To test a temporary error, we redefine receive-messages to throw
-        ;;           an error once and afterwards do what the original function did,
-        ;;           which we saved previously:
-        (with-redefs-fn {#'sqs/wait-and-receive-messages-from-sqs
-                         (fn [sqs-client queue-url wait-time-in-seconds]
-                           (swap! called-counter inc)
-                           (if (= @called-counter 1)
-                               (throw (HttpTimeoutException. "Testing temporary network failure"))
-                               (wait-and-receive-messages-from-sqs sqs-client queue-url wait-time-in-seconds)))}
-          #(bond/with-spy [receive/pause-to-recover-this-loop]
-             (let [restart-delay-seconds 1]
-               (fixtures/with-handle-queue
-                 handler-chan
-                 {:handler-opts   {:restart-delay-seconds restart-delay-seconds}}
+  (let [handler-chan (chan)
+        wait-and-receive-messages-from-sqs sqs/wait-and-receive-messages-from-sqs
+        called-counter (atom 0)]
+    (fixtures/with-test-standard-queue
+      ;; WATCHOUT: To test a temporary error, we redefine receive-messages to throw
+      ;;           an error once and afterwards do what the original function did,
+      ;;           which we saved previously:
+      (with-redefs-fn {#'sqs/wait-and-receive-messages-from-sqs
+                       (fn [sqs-client queue-url wait-time-in-seconds]
+                         (swap! called-counter inc)
+                         (if (= @called-counter 1)
+                           (throw (HttpTimeoutException. "Testing temporary network failure"))
+                           (wait-and-receive-messages-from-sqs sqs-client queue-url wait-time-in-seconds)))}
+        #(bond/with-spy [receive/pause-to-recover-this-loop]
+           (let [restart-delay-seconds 1]
+             (fixtures/with-handle-queue
+               handler-chan
+               {:handler-opts   {:restart-delay-seconds restart-delay-seconds}}
 
-                 ;; give the loop some time to handle that error ...
-                 (Thread/sleep (+ (* restart-delay-seconds 1000) 200))
-                 (is (= 1
-                        (-> receive/pause-to-recover-this-loop
-                            (bond/calls)
-                            (count))))
+               ;; give the loop some time to handle that error ...
+               (Thread/sleep (+ (* restart-delay-seconds 1000) 200))
+               (is (= 1
+                      (-> receive/pause-to-recover-this-loop
+                          (bond/calls)
+                          (count))))
 
-                 ;; verify that sending/receiving still works ...
-                 (is (sqs-ext/send-message fixtures/sqs-ext-config
-                                           @fixtures/test-queue-url
-                                           test-message-with-time))
-                 (is (not (clojure.core.async.impl.protocols/closed? handler-chan)))
-                 (is (= test-message-with-time
-                        (-> (alts!! [handler-chan (timeout 1000)])
-                            (first)))))))))
-      (close! handler-chan))))
+               ;; verify that sending/receiving still works ...
+               (is (sqs-ext/send-message fixtures/sqs-ext-config
+                                         @fixtures/test-queue-url
+                                         test-message-with-time))
+               (is (not (clojure.core.async.impl.protocols/closed? handler-chan)))
+               (is (= test-message-with-time
+                      (-> (alts!! [handler-chan (timeout 1000)])
+                          (first)))))))))
+    (close! handler-chan)))
 
 (deftest handle-queue-terminates-upon-unrecoverable-error-occured
-  (testing "handle-queue terminates when an error occured that was considered fatal/unrecoverable"
-    (let [handler-chan (chan)]
-      (fixtures/with-test-standard-queue
-        (with-redefs-fn {#'sqs/receive-messages
-                         (fn [_ _ _]
-                           (throw (RuntimeException. "Testing runtime error")))}
-          #(bond/with-spy [receive/stop-receive-loop!]
-             (fixtures/with-handle-queue-defaults handler-chan
+  (let [handler-chan (chan)]
+    (fixtures/with-test-standard-queue
+      (with-redefs-fn {#'sqs/receive-messages
+                       (fn [_ _ _]
+                         (throw (RuntimeException. "Testing runtime error")))}
+        #(bond/with-spy [receive/stop-receive-loop!]
+           (fixtures/with-handle-queue-defaults handler-chan
 
-               (Thread/sleep 100)
-               (is (= 1
-                      (-> receive/stop-receive-loop!
-                          (bond/calls)
-                          (count))))))))
-      (close! handler-chan))))
+             (Thread/sleep 100)
+             (is (= 1
+                    (-> receive/stop-receive-loop!
+                        (bond/calls)
+                        (count))))))))
+    (close! handler-chan)))
 
 (deftest nil-returned-after-loop-was-terminated
-  (testing "Stopping the listener yields nil response when receiving from the channel again"
-    (fixtures/with-test-standard-queue
-      (let [out-chan (chan)
-            stop-fn (sqs-ext/receive-loop fixtures/sqs-ext-config
-                                          @fixtures/test-queue-url
-                                          out-chan)]
-        (is (fn? stop-fn))
-        (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
-                                           @fixtures/test-queue-url
-                                           (first test-messages-basic))))
-        (is (= (first test-messages-basic) (:body (<!! out-chan))))
+  (fixtures/with-test-standard-queue
+    (let [out-chan (chan)
+          stop-fn (sqs-ext/receive-loop fixtures/sqs-ext-config
+                                        @fixtures/test-queue-url
+                                        out-chan)]
+      (is (fn? stop-fn))
+      (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
+                                         @fixtures/test-queue-url
+                                         (first test-messages-basic))))
+      (is (= (first test-messages-basic) (:body (<!! out-chan))))
 
-        ;; terminate receive loop and thereby close the out-channel
-        (stop-fn)
+      ;; terminate receive loop and thereby close the out-channel
+      (stop-fn)
 
-        (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
-                                           @fixtures/test-queue-url
-                                           (last test-messages-basic))))
-        (is (clojure.core.async.impl.protocols/closed? out-chan))
-        (is (nil? (<!! out-chan)))))))
+      (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
+                                         @fixtures/test-queue-url
+                                         (last test-messages-basic))))
+      (is (clojure.core.async.impl.protocols/closed? out-chan))
+      (is (nil? (<!! out-chan))))))
 
 (deftest manually-deleted-messages-dont-get-resent
-  (testing "Messages deleted by invoking the done-fn handle are not resent"
-    (bond/with-spy [fixtures/test-handler-fn]
-      (let [handler-chan (chan)]
-        (fixtures/with-test-standard-queue
-          (fixtures/with-handle-queue
-            handler-chan
-            {:handler-opts {:auto-delete false}}
+  (bond/with-spy [fixtures/test-handler-fn]
+    (let [handler-chan (chan)]
+      (fixtures/with-test-standard-queue
+        (fixtures/with-handle-queue
+          handler-chan
+          {:handler-opts {:auto-delete false}}
 
-            (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
-                                               @fixtures/test-queue-url
-                                               (last test-messages-basic))))
+          (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
+                                             @fixtures/test-queue-url
+                                             (last test-messages-basic))))
 
-            (let [received-message (<!! handler-chan)]
-              ;; message received properly
-              (is (= (last test-messages-basic) received-message))
+          (let [received-message (<!! handler-chan)]
+            ;; message received properly
+            (is (= (last test-messages-basic) received-message))
 
-              ;; delete function handle is returned as last argument ...
-              (let [test-handler-fn-args
-                    (-> fixtures/test-handler-fn bond/calls first :args)]
-                (is (fn? (last test-handler-fn-args))))
+            ;; delete function handle is returned as last argument ...
+            (let [test-handler-fn-args
+                  (-> fixtures/test-handler-fn bond/calls first :args)]
+              (is (fn? (last test-handler-fn-args))))
 
-              ;; delete it manually now ...
-              (@fixtures/test-handler-done-fn)
+            ;; delete it manually now ...
+            (@fixtures/test-handler-done-fn)
 
-              ;; verify its not received again ...
-              (is (alt!!
-                    handler-chan false
-                    (timeout 1000) true)))))
+            ;; verify its not received again ...
+            (is (alt!!
+                  handler-chan false
+                  (timeout 1000) true)))))
 
-        (close! handler-chan)))))
+      (close! handler-chan))))
 
 (deftest messages-get-resent-if-not-deleted-manually-and-auto-delete-is-false
   (bond/with-spy [fixtures/test-handler-fn]
@@ -368,45 +360,44 @@
           (recur))))))
 
 (deftest done-fn-handle-absent-when-auto-delete-true
-  (testing "done-fn handle is not present in response when auto-delete is true"
-    (bond/with-spy [fixtures/test-handler-fn]
-      (let [handler-chan (chan)]
-        (fixtures/with-test-standard-queue
-          (with-redefs-fn {#'sqs-ext/launch-handler-threads
-                           launch-handler-threads-with-complete-sqs-message-forwarding}
-            #(fixtures/with-handle-queue
-               handler-chan
-               {:handler-opts {:auto-delete true}}
+  (bond/with-spy [fixtures/test-handler-fn]
+    (let [handler-chan (chan)]
+      (fixtures/with-test-standard-queue
+        (with-redefs-fn {#'sqs-ext/launch-handler-threads
+                         launch-handler-threads-with-complete-sqs-message-forwarding}
+          #(fixtures/with-handle-queue
+             handler-chan
+             {:handler-opts {:auto-delete true}}
 
-               (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
-                                                  @fixtures/test-queue-url
-                                                  (first test-messages-basic))))
-
-               (let [received-message (<!! handler-chan)]
-                 (is (= (first test-messages-basic) (:body received-message)))
-
-                 ;; no delete function handle has been passed as last argument ...
-                 (let [test-handler-fn-args
-                       (-> fixtures/test-handler-fn bond/calls first :args)]
-                   (is (not (fn? (last test-handler-fn-args)))))
-
-                 ;; not sure why this is needed, but otherwise the next check
-                 ;; becomes an intermittent fail
-                 (Thread/sleep 50)
-
-                 ;; WATCHOUT: With the handler thread redeffed we can now access
-                 ;;           the receipt handle of the SQS message and try to
-                 ;;           delete the message manually. If the message was
-                 ;;           auto-deleted by the core API before this should
-                 ;;           yield an AmazonSQSException:
-                 (is (thrown-with-msg?
-                       AmazonSQSException
-                       #"^.*Service: AmazonSQS; Status Code: 400;.*$"
-                       (sqs-ext/delete-message! fixtures/sqs-ext-config
+             (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
                                                 @fixtures/test-queue-url
-                                                received-message)))))))
+                                                (first test-messages-basic))))
 
-        (close! handler-chan)))))
+             (let [received-message (<!! handler-chan)]
+               (is (= (first test-messages-basic) (:body received-message)))
+
+               ;; no delete function handle has been passed as last argument ...
+               (let [test-handler-fn-args
+                     (-> fixtures/test-handler-fn bond/calls first :args)]
+                 (is (not (fn? (last test-handler-fn-args)))))
+
+               ;; not sure why this is needed, but otherwise the next check
+               ;; becomes an intermittent fail
+               (Thread/sleep 50)
+
+               ;; WATCHOUT: With the handler thread redeffed we can now access
+               ;;           the receipt handle of the SQS message and try to
+               ;;           delete the message manually. If the message was
+               ;;           auto-deleted by the core API before this should
+               ;;           yield an AmazonSQSException:
+               (is (thrown-with-msg?
+                     AmazonSQSException
+                     #"^.*Service: AmazonSQS; Status Code: 400;.*$"
+                     (sqs-ext/delete-message! fixtures/sqs-ext-config
+                                              @fixtures/test-queue-url
+                                              received-message)))))))
+
+      (close! handler-chan))))
 
 (deftest error-is-safe-to-continue?-test
   (are [severity error]
@@ -418,22 +409,20 @@
        false (ReflectiveOperationException.)))
 
 (deftest unreachable-endpoint-yields-proper-exception
-  (testing "Trying to connect to an unreachable endpoint yields a proper exception"
-    (let [unreachable-sqs-ext-config (merge fixtures/sqs-ext-config
-                                        {:sqs-endpoint "https://unreachable-endpoint"
-                                         :s3-endpoint  "https://unreachable-endpoint"})]
-      (is (thrown? SdkClientException
-                   (sqs-ext/send-message unreachable-sqs-ext-config
-                                         @fixtures/test-queue-url
-                                         {:data "here-be-dragons"}))))))
+  (let [unreachable-sqs-ext-config (merge fixtures/sqs-ext-config
+                                          {:sqs-endpoint "https://unreachable-endpoint"
+                                           :s3-endpoint  "https://unreachable-endpoint"})]
+    (is (thrown? SdkClientException
+                 (sqs-ext/send-message unreachable-sqs-ext-config
+                                       @fixtures/test-queue-url
+                                       {:data "here-be-dragons"})))))
 
-(deftest cannot-send-to-non-existing-bucket
-  (testing "Sending a large message using a non-existing S3 bucket yields proper exception"
-    (fixtures/with-test-standard-queue
-      (let [non-existing-bucket-sqs-ext-config (assoc fixtures/sqs-ext-config
-                                                  :s3-bucket-name
-                                                  "non-existing-bucket")]
-        (is (thrown? AmazonServiceException
-                     (sqs-ext/send-message non-existing-bucket-sqs-ext-config
-                                           "test-queue"
-                                           (helpers/random-message-larger-than-256kb))))))))
+(deftest cannot-send-large-message-to-non-existing-s3-bucket
+  (fixtures/with-test-standard-queue
+    (let [non-existing-bucket-sqs-ext-config (assoc fixtures/sqs-ext-config
+                                                    :s3-bucket-name
+                                                    "non-existing-bucket")]
+      (is (thrown? AmazonServiceException
+                   (sqs-ext/send-message non-existing-bucket-sqs-ext-config
+                                         "test-queue"
+                                         (helpers/random-message-larger-than-256kb)))))))

--- a/test/clj_sqs_extended/core_test.clj
+++ b/test/clj_sqs_extended/core_test.clj
@@ -61,7 +61,7 @@
                                                        (helpers/random-group-id)))))))
 
 (defn timed-take!!
-  ([c] (timed-take!! c 1000))
+  ([c] (timed-take!! c 3000))
 
   ([c timeout-in-ms]
    (-> (alts!! [c (timeout timeout-in-ms)])

--- a/test/clj_sqs_extended/core_test.clj
+++ b/test/clj_sqs_extended/core_test.clj
@@ -75,24 +75,27 @@
           handler-chan
 
           (testing "handle-queue can send/receive basic messages to standard queue"
-            (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
-                                               @fixtures/test-queue-url
-                                               (first test-messages-basic)
-                                               {:format format})))
-            (is (= (first test-messages-basic) (timed-take!! handler-chan)))
-
-            (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
+            (let [message (first test-messages-basic)]
+              (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
                                                  @fixtures/test-queue-url
-                                                 (first test-messages-basic)
+                                                 message
                                                  {:format format})))
-            (is (= (first test-messages-basic) (timed-take!! handler-chan))))
+              (is (= message (timed-take!! handler-chan)))
+
+              (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
+                                                 @fixtures/test-queue-url
+                                                 message
+                                                 {:format format})))
+              (is (= message (timed-take!! handler-chan)))))
 
           (testing "handle-queue can send/receive large message to standard queue"
             (is (string? (sqs-ext/send-message fixtures/sqs-ext-config
                                                @fixtures/test-queue-url
                                                test-message-large
                                                {:format format})))
-            (is (= test-message-large (timed-take!! handler-chan))))))
+            (is (true? ;; wrapping this in a true? so that if this test fails,
+                       ;; it doesn't print the whole giant message
+                  (= test-message-large (timed-take!! handler-chan 2000)))))))
       (close! handler-chan))))
 
 (deftest handle-queue-sends-and-receives-messages-without-bucket

--- a/test/clj_sqs_extended/integration_test.clj
+++ b/test/clj_sqs_extended/integration_test.clj
@@ -41,11 +41,7 @@
         (is (= [msg1] (<!! c)))
 
         (is (sqs-ext/send-message (sqs-ext-config) standard-queue-url msg2 {:format :json}))
-        (is (= [msg2] (<!! c)))
-
-        ;; stops receive-loop
-        (let [stats (stop-fn)]
-          (is (= 0 (:restart-count stats)))))))
+        (is (= [msg2] (<!! c))))))
 
   (testing "Large 256kb+ message, S3-backed SQS"
     ;; TODO

--- a/test/clj_sqs_extended/test_fixtures.clj
+++ b/test/clj_sqs_extended/test_fixtures.clj
@@ -35,14 +35,14 @@
 
 (defn wrap-standard-queue
   [opts f]
-  (reset! test-queue-url
-          (sqs-ext/create-standard-queue! sqs-ext-config
-                                          (test-standard-queue-name)
-                                          opts))
-  (f)
-  (Thread/sleep 50) ;; wait for receive-loop to finish in the background
-  (sqs-ext/delete-queue! sqs-ext-config
-                         @test-queue-url))
+  (let [queue-url (sqs-ext/create-standard-queue!
+                    sqs-ext-config
+                    (test-standard-queue-name)
+                    opts)]
+    (reset! test-queue-url queue-url)
+    (f)
+    (Thread/sleep 200) ;; wait for receive-loop to finish in the background
+    (sqs-ext/delete-queue! sqs-ext-config queue-url)))
 
 (defmacro with-test-standard-queue
   [& body]
@@ -56,13 +56,14 @@
 
 (defn wrap-fifo-queue
   [f]
-  (reset! test-queue-url
-          (sqs-ext/create-fifo-queue! sqs-ext-config
-                                      (test-fifo-queue-name)))
-  (f)
-  (Thread/sleep 50) ;; wait for receive-loop to finish in the background
-  (sqs-ext/delete-queue! sqs-ext-config
-                         @test-queue-url))
+  (let [queue-url (sqs-ext/create-fifo-queue!
+                    sqs-ext-config
+                    (test-fifo-queue-name))]
+    (reset! test-queue-url queue-url)
+    (f)
+    (Thread/sleep 200) ;; wait for receive-loop to finish in the background
+    (sqs-ext/delete-queue! sqs-ext-config
+                           queue-url)))
 
 (defmacro with-test-fifo-queue
   [& body]

--- a/test/clj_sqs_extended/test_fixtures.clj
+++ b/test/clj_sqs_extended/test_fixtures.clj
@@ -16,8 +16,8 @@
 
 (defonce test-sqs-ext-client (atom nil))
 (defonce test-queue-url (atom nil))
-(defonce test-standard-queue-name (helpers/random-queue-name))
-(defonce test-fifo-queue-name (helpers/random-queue-name {:suffix ".fifo"}))
+(def test-standard-queue-name helpers/random-queue-name)
+(def test-fifo-queue-name (partial helpers/random-queue-name {:suffix ".fifo"}))
 (defonce test-handler-done-fn (atom nil))
 
 (defn with-test-sqs-ext-client
@@ -37,7 +37,7 @@
   [opts f]
   (reset! test-queue-url
           (sqs-ext/create-standard-queue! sqs-ext-config
-                                          test-standard-queue-name
+                                          (test-standard-queue-name)
                                           opts))
   (f)
   (Thread/sleep 50) ;; wait for receive-loop to finish in the background
@@ -58,7 +58,7 @@
   [f]
   (reset! test-queue-url
           (sqs-ext/create-fifo-queue! sqs-ext-config
-                                      test-fifo-queue-name))
+                                      (test-fifo-queue-name)))
   (f)
   (Thread/sleep 50) ;; wait for receive-loop to finish in the background
   (sqs-ext/delete-queue! sqs-ext-config

--- a/test/clj_sqs_extended/test_fixtures.clj
+++ b/test/clj_sqs_extended/test_fixtures.clj
@@ -83,7 +83,10 @@
                                       (partial test-handler-fn handler-chan))]
     (f)
     (if (:auto-stop-loop settings)
-      (stop-fn)
+      (do
+        (stop-fn)
+        ;; wait for receive-loop async teardown
+        (Thread/sleep 100))
       stop-fn)))
 
 (defmacro with-handle-queue-defaults


### PR DESCRIPTION
Main change happens in receive/receive-loop. 

And then a whole load of commits to fix the tests. This suggest that there is too much implementation coupling between tests and source. I'll create a new issue #102 for this.