### PR TITLE
clj-sqs-ext should not receive message until there is an available handler process

### DIFF
--- a/src/clj_sqs_extended/aws/sqs.clj
+++ b/src/clj_sqs_extended/aws/sqs.clj
@@ -258,7 +258,7 @@
 (defn receive-to-channel
   [sqs-client queue-url
    {:keys [max-number-of-receiving-messages]
-    :or {max-number-of-receiving-messages 10}
+    :or {max-number-of-receiving-messages 1}
     :as opts}]
   (let [ch (chan max-number-of-receiving-messages)]
     (async/thread

--- a/src/clj_sqs_extended/aws/sqs.clj
+++ b/src/clj_sqs_extended/aws/sqs.clj
@@ -258,7 +258,6 @@
 (defn receive-to-channel
   [sqs-client queue-url
    {:keys [max-number-of-receiving-messages]
-    :or {max-number-of-receiving-messages 1}
     :as opts}]
   (let [ch (chan max-number-of-receiving-messages)]
     (async/thread

--- a/src/clj_sqs_extended/aws/sqs.clj
+++ b/src/clj_sqs_extended/aws/sqs.clj
@@ -188,10 +188,8 @@
           (bean)
           (select-keys [:messageId :receiptHandle :body])))
 
-(def ^:private max-number-of-receiving-messages (int 10))
-
 (defn- receive-messages-request
-  [queue-url wait-time-in-seconds]
+  [queue-url wait-time-in-seconds max-number-of-receiving-messages]
   (doto (ReceiveMessageRequest. queue-url)
       (.setWaitTimeSeconds (int wait-time-in-seconds))
       ;; this below is to satisfy some quirk with SQS for our custom serdes-format attribute to be received
@@ -199,8 +197,10 @@
       (.setMaxNumberOfMessages max-number-of-receiving-messages)))
 
 (defn wait-and-receive-messages-from-sqs
-  [sqs-client queue-url wait-time-in-seconds]
-  (->> (receive-messages-request queue-url wait-time-in-seconds)
+  [sqs-client queue-url
+   {wait-time-in-seconds             :wait-time-in-seconds
+    max-number-of-receiving-messages :max-number-of-receiving-messages}]
+  (->> (receive-messages-request queue-url wait-time-in-seconds max-number-of-receiving-messages)
        (.receiveMessage sqs-client)
        (.getMessages)))
 
@@ -227,7 +227,8 @@
    (receive-messages sqs-client queue-url {}))
 
   ([sqs-client queue-url
-    {:keys [wait-time-in-seconds]
+    {:keys [wait-time-in-seconds
+            max-number-of-receiving-messages]
      ;; Defaults to maximum long polling
      ;; https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
      :or   {wait-time-in-seconds 20}}]
@@ -236,7 +237,8 @@
        (->> (wait-and-receive-messages-from-sqs
               sqs-client
               queue-url
-              wait-time-in-seconds)
+              {:wait-time-in-seconds             wait-time-in-seconds
+               :max-number-of-receiving-messages max-number-of-receiving-messages})
             (map parse-message)
             (map deserialize-message-if-formatted))
        (catch Throwable ex
@@ -254,7 +256,10 @@
   `(throw-err (clojure.core.async/<!! ~channel)))
 
 (defn receive-to-channel
-  [sqs-client queue-url opts]
+  [sqs-client queue-url
+   {:keys [max-number-of-receiving-messages]
+    :or {max-number-of-receiving-messages 10}
+    :as opts}]
   (let [ch (chan max-number-of-receiving-messages)]
     (async/thread
       (try

--- a/src/clj_sqs_extended/core.clj
+++ b/src/clj_sqs_extended/core.clj
@@ -103,7 +103,8 @@
                   handler-chan
                   {:auto-delete           auto-delete
                    :restart-limit         restart-limit
-                   :restart-delay-seconds restart-delay-seconds})]
+                   :restart-delay-seconds restart-delay-seconds}
+                  {})]
     (log/infof (str "Handling queue '%s' with bucket [%s], "
                     "number-of-handler-threads [%d], "
                     "restart-limit [%d], "

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -183,8 +183,8 @@
             restart-delay-seconds
             restart-limit]
      :as   receive-opts}
-    {:keys [max-number-of-receiving-messages
-            wait-time-in-seconds]
+    {:keys [max-number-of-receiving-messages]
+     :or   {max-number-of-receiving-messages 1}
      :as   sqs-opts}]
    (let [receive-loop-running? (atom true)
          create-new-receiving-chan-fn

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -174,7 +174,7 @@
 
 (defn receive-loop
   ([sqs-ext-client queue-url out-chan]
-   (receive-loop sqs-ext-client queue-url out-chan {}))
+   (receive-loop sqs-ext-client queue-url out-chan {} {}))
 
   ([sqs-ext-client
     queue-url
@@ -182,12 +182,16 @@
     {:keys [auto-delete
             restart-delay-seconds
             restart-limit]
-     :as   receive-opts}]
+     :as   receive-opts}
+    {:keys [max-number-of-receiving-messages
+            wait-time-in-seconds]
+     :as   sqs-opts}]
    (let [receive-loop-running? (atom true)
-         create-new-receiving-chan-fn #(sqs/receive-to-channel
-                                         sqs-ext-client
-                                         queue-url
-                                         {})]
+         create-new-receiving-chan-fn
+         #(sqs/receive-to-channel
+            sqs-ext-client
+            queue-url
+            sqs-opts)]
      (go-loop
        [loop-stats        (init-receive-loop-stats)
         receiving-chan    (create-new-receiving-chan-fn)

--- a/test/clj_sqs_extended/internal/receive_test.clj
+++ b/test/clj_sqs_extended/internal/receive_test.clj
@@ -50,7 +50,8 @@
                      sqs-ext-client
                      @fixtures/test-queue-url
                      c
-                     {:auto-delete true})))]
+                     {:auto-delete true}
+                     {})))]
 
       (is (= n (count stop-receive-loops)))
       (is (every? fn? stop-receive-loops))


### PR DESCRIPTION
Story details: https://app.clubhouse.io/motiva/story/7700