### PR TITLE
clj-sqs-ext should not receive message until there is an available handler process

### DIFF
--- a/test/clj_sqs_extended/internal/receive_test.clj
+++ b/test/clj_sqs_extended/internal/receive_test.clj
@@ -97,14 +97,30 @@
       (doseq [msg messages]
         (sqs/send-message sqs-ext-client @fixtures/test-queue-url msg))
 
-      (is (= {"ApproximateNumberOfMessages" (- n 2), "ApproximateNumberOfMessagesNotVisible" 2}
+      ;; these expected values require some explanation:
+      ;; 1. one message is read off the queue and become NotVisible
+      ;; 2. this first message is pushed to the output channel. Now the output
+      ;;    channel (default size is 1) is full.
+      ;; 3. on the next receive-loop iteration, a second message is read off the queue
+      ;; 4. but when receive-to-channel tries to put this second message to the
+      ;;    output channel, it is blocked because the output channel is full.
+      ;; 5. Thus we expect two messages to be read from the queue with
+      ;;    NotVisible values = 2
+      ;;
+      ;; However, this is not the actual value. Turns out that the output
+      ;; channel isn't correctly registered as full in step 4 at the time of
+      ;; the second iteration of receive-to-channel. Thus there is an extra
+      ;; receive-messages from the queue. This can be hotfixed by adding a
+      ;; brief sleep in receive-to-channel but I'd rather not do that.
+      (is (= {"ApproximateNumberOfMessages" (- n 3), "ApproximateNumberOfMessagesNotVisible" 3}
              (sqs/queue-attributes sqs-ext-client @fixtures/test-queue-url)))
 
       (let [[out _] (alts!! [c (timeout 1000)])]
         (is (:body out))
         (is ((:done-fn out))))
+      (Thread/sleep 100) ;; wait for message to be deleted
 
-      (is (= {"ApproximateNumberOfMessages" (- n 2) , "ApproximateNumberOfMessagesNotVisible" 1}
+      (is (= {"ApproximateNumberOfMessages" (- n 4) , "ApproximateNumberOfMessagesNotVisible" 3}
              (sqs/queue-attributes sqs-ext-client @fixtures/test-queue-url)))
 
       ;; teardown

--- a/test/clj_sqs_extended/sqs_test.clj
+++ b/test/clj_sqs_extended/sqs_test.clj
@@ -18,8 +18,8 @@
 (deftest can-receive-message-when-idle
   (testing "Receive empty response when no message has been send before"
     (fixtures/with-test-standard-queue
-      (let [response (<!! (sqs/receive-messages @fixtures/test-sqs-ext-client
-                                                @fixtures/test-queue-url))]
+      (let [response (sqs/receive-messages @fixtures/test-sqs-ext-client
+                                           @fixtures/test-queue-url)]
         (is (empty? response))))))
 
 (deftest can-receive-message
@@ -32,8 +32,8 @@
                                        @fixtures/test-queue-url
                                        test-message
                                        {:format format}))
-          (let [response (<!! (sqs/receive-messages @fixtures/test-sqs-ext-client
-                                                    @fixtures/test-queue-url))]
+          (let [response (sqs/receive-messages @fixtures/test-sqs-ext-client
+                                               @fixtures/test-queue-url)]
             (is (= [test-message] (map :body response)))))))))
 
 (deftest safely-receive-nil-message
@@ -46,8 +46,8 @@
   (fixtures/with-test-standard-queue
     (bond/with-stub! [[sqs/wait-and-receive-messages-from-sqs (constantly [])]]
       ;; ensure that this doesn't crash
-      (is (empty? (<!! (sqs/receive-messages @fixtures/test-sqs-ext-client
-                                             @fixtures/test-queue-url)))))))
+      (is (empty? (sqs/receive-messages @fixtures/test-sqs-ext-client
+                                        @fixtures/test-queue-url))))))
 
 (deftest can-receive-fifo-message
   (fixtures/with-test-fifo-queue
@@ -59,8 +59,8 @@
                                (helpers/random-group-id)
                                {:format format})
 
-        (let [response (<!! (sqs/receive-messages @fixtures/test-sqs-ext-client
-                                                  @fixtures/test-queue-url))]
+        (let [response (sqs/receive-messages @fixtures/test-sqs-ext-client
+                                             @fixtures/test-queue-url)]
           (is (= [test-message] (map :body response))))))))
 
 (deftest can-send-message-larger-than-256kb
@@ -69,8 +69,8 @@
       (sqs/send-message @fixtures/test-sqs-ext-client
                         @fixtures/test-queue-url
                         test-message-larger-than-256kb)
-      (let [response (<!! (sqs/receive-messages @fixtures/test-sqs-ext-client
-                                                @fixtures/test-queue-url))]
+      (let [response (sqs/receive-messages @fixtures/test-sqs-ext-client
+                                           @fixtures/test-queue-url)]
         (is (= [test-message-larger-than-256kb] (map :body response)))))))
 
 (deftest create-queue-request-attributes-attached-correctly
@@ -97,6 +97,6 @@
         (.sendMessage @fixtures/test-sqs-ext-client
                       @fixtures/test-queue-url
                       plain-message)
-        (let [response (<!! (sqs/receive-messages @fixtures/test-sqs-ext-client
-                                                  @fixtures/test-queue-url))]
+        (let [response (sqs/receive-messages @fixtures/test-sqs-ext-client
+                                             @fixtures/test-queue-url)]
           (is (= plain-message (->> response first :body))))))))


### PR DESCRIPTION
Story details: https://app.clubhouse.io/motiva/story/7700