### PR TITLE
Refactor/receive loop side effects alternate

### DIFF
--- a/src/clj_sqs_extended/core.clj
+++ b/src/clj_sqs_extended/core.clj
@@ -77,13 +77,13 @@
    handler-fn]
   (let [handler-chan (chan)
         stop-fn (receive/receive-loop
-                  sqs-ext-client
                   queue-url
                   handler-chan
-                  {:auto-delete           auto-delete
-                   :restart-limit         restart-limit
-                   :restart-delay-seconds restart-delay-seconds}
-                  {})]
+                  (partial sqs/receive-messages sqs-ext-client queue-url)
+                  (partial sqs/delete-message! sqs-ext-client queue-url)
+                  {:auto-delete? auto-delete
+                   :restart-opts {:restart-limit         restart-limit
+                                  :restart-delay-seconds restart-delay-seconds}})]
     (log/infof (str "Handling queue '%s' with: "
                     "number-of-handler-threads [%d], "
                     "restart-limit [%d], "

--- a/src/clj_sqs_extended/internal/receive.clj
+++ b/src/clj_sqs_extended/internal/receive.clj
@@ -80,9 +80,7 @@
          #(async-delete-message! sqs-ext-client queue-url message)))
 
 (defn put-legit-message-to-out-chan
-  [{queue-url      :queue-url
-    out-chan       :out-chan}
-   message]
+  [queue-url out-chan message]
   (if (:body message)
     (when-not (>!! out-chan message)
       ;; TODO refactor this fn's logic so that we don't need to throw an exception to stop auto-delete
@@ -228,11 +226,7 @@
                   pause-and-restart-for-error?
                   receive-opts)
                 (assoc-done-fn-to-message sqs-ext-client queue-url)
-                (put-legit-message-to-out-chan
-                  {:sqs-ext-client sqs-ext-client
-                   :queue-url      queue-url
-                   :out-chan       out-chan
-                   :auto-delete?   auto-delete})
+                (put-legit-message-to-out-chan queue-url out-chan)
                 (delete-message-if-auto-delete auto-delete))
 
        (if @receive-loop-running?


### PR DESCRIPTION
another refactor in pursuit of #121. `receive-loop` is nearly side-effect free. next step is to re-write `receive-test` namespace to not need sqs-ext-client at all.
